### PR TITLE
allow aria-labelledBy and aria-hidden attributes

### DIFF
--- a/src/coconut/react/macros/Html.hx
+++ b/src/coconut/react/macros/Html.hx
@@ -42,7 +42,7 @@ class Html {
           var fields = (macro class { 
             @:optional var key(default, never):coconut.react.Key; 
             @:optional var ref(default, never):coconut.ui.Ref<$et>;
-            @:hxxCustomAttributes(~/^(aria-(selected|label))|(data-.*)$/)
+            @:hxxCustomAttributes(~/^(aria-(selected|label|labelledBy|hidden))|(data-.*)$/)
             @:optional var $NAMELESS(default, never):CustomAttr;
           }).fields;
 


### PR DESCRIPTION
This adds recognition for 2 high frequency aria attributes (for accessibility APIs).
I previously tried to address that in tink_domspec before realizing after reading back2dos messages it was actually in one regex here.